### PR TITLE
removed mapping between domain record and do project

### DIFF
--- a/packages/infrastructure/digitalocean.tf
+++ b/packages/infrastructure/digitalocean.tf
@@ -35,7 +35,6 @@ resource "digitalocean_project_resources" "project-to-resource-mapping" {
     digitalocean_droplet.manager-droplet.urn,
     digitalocean_database_cluster.database-cluster.urn,
     digitalocean_domain.default.urn,
-    digitalocean_record.www.id
   ]
 }
 


### PR DESCRIPTION
This mapping breaks deploy because `id` is not the same as a `urn`. Furthermore, the mapping was unecessary, as the domain is already mapped.