### PR TITLE
remove http redirect logic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -192,7 +192,6 @@ jobs:
               PGPORT=${{ steps.infrastructure-output.outputs.database_port }}
               DATABASE_CA=${{ secrets.DATABASE_CA }} \ 
               GATEWAY_PORT=${{ secrets.GATEWAY_PORT }} \
-              GATEWAY_HTTP_PORT=${{ secrets.GATEWAY_HTTP_PORT }} \
               WEB_PORT=${{ secrets.WEB_PORT }} \
               API_PORT=${{ secrets.API_PORT }} \
               AUTHENTICATION_PORT=${{ secrets.AUTHENTICATION_PORT }} \
@@ -211,7 +210,6 @@ jobs:
               PGPORT=$PGPORT \ 
               DATABASE_CA=$DATABASE_CA \
               GATEWAY_PORT=$GATEWAY_PORT \
-              GATEWAY_HTTP_PORT=$GATEWAY_HTTP_PORT \
               WEB_PORT=$WEB_PORT \
               API_PORT=$API_PORT \
               AUTHENTICATION_PORT=$AUTHENTICATION_PORT \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This will allow me to give you perks in return for your gratitude!
 
 - `.env` containing:
   - GATEWAY_PORT=8080
-  - GATEWAY_HTTP_PORT=8088
   - API_PORT=8082
   - AUTHENTICATION_PORT=8081
   - WEB_PORT=3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - .:/paperpod
     environment:
       - PORT=$GATEWAY_PORT
-      - GATEWAY_HTTP_PORT=$GATEWAY_HTTP_PORT
       - WEB_PORT=$WEB_PORT
       - DOCS_PORT=$DOCS_PORT
       - API_PORT=$API_PORT

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,6 +1,4 @@
-import fs from "fs";
 import http from "http";
-import https from "https";
 import * as server from "@paperpod/server";
 import { withProxies, mapping } from "./proxy";
 import { logger } from "@paperpod/common";
@@ -19,40 +17,6 @@ export const app = withProxies(
   server.app.appWithEnvironment()
 );
 
-const actualServer =
-  // process.env.NODE_ENV === "production"
-  false //FIXME: add back production check when certs are fixed
-    ? https.createServer(
-        {
-          key: fs.readFileSync(
-            "/etc/letsencrypt/live/paperpod.fm/privkey.pem",
-            "utf8"
-          ),
-          cert: fs.readFileSync(
-            "/etc/letsencrypt/live/paperpod.fm/cert.pem",
-            "utf8"
-          ),
-          ca: fs.readFileSync(
-            "/etc/letsencrypt/live/paperpod.fm/chain.pem",
-            "utf8"
-          ),
-        },
-        app
-      )
-    : http.createServer(app);
-
-const redirectServer = http.createServer(
-  server.app.appWithEnvironment().use((request, response) => {
-    response.redirect(`https://${request.headers.host}${request.url}`);
-  })
-);
-
-redirectServer.listen(process.env.GATEWAY_HTTP_PORT, () => {
-  logger.info(
-    `Redirecting to HTTPS from port ${process.env.GATEWAY_HTTP_PORT}`
-  );
-});
-
-actualServer.listen(process.env.PORT, () => {
+http.createServer(app).listen(process.env.PORT, () => {
   logger.info(`Listening on ${process.env.PORT}`);
 });

--- a/scripts/stack.yml
+++ b/scripts/stack.yml
@@ -4,16 +4,11 @@ services:
     image: olaven/paperpod-gateway@$GATEWAY_DIGEST
     ports:
       - $GATEWAY_PORT:$GATEWAY_PORT
-      - $GATEWAY_HTTP_PORT:$GATEWAY_HTTP_PORT
     environment:
       - PORT=$GATEWAY_PORT
       - WEB_PORT=$WEB_PORT
       - API_PORT=$API_PORT
       - AUTHENTICATION_PORT=$AUTHENTICATION_PORT
-    #volumes: # FIXME: add once certbot has run
-    #  - /etc/letsencrypt/live/paperpod.fm/privkey.pem:/etc/letsencrypt/live/paperpod.fm/privkey.pem
-    #  - /etc/letsencrypt/live/paperpod.fm/cert.pem:/etc/letsencrypt/live/paperpod.fm/cert.pem
-    #  - /etc/letsencrypt/live/paperpod.fm/chain.pem:/etc/letsencrypt/live/paperpod.fm/chain.pem
   api:
     image: olaven/paperpod-api@$API_DIGEST
     environment:
@@ -27,7 +22,6 @@ services:
       - PGPORT=$PGPORT
       - PGSSLMODE=require
       - PAPERPOD_SCHEMA=api
-      #- PGOPTIONS="-c search_path=api'
       - DATABASE_CA=$DATABASE_CA
       - AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
@@ -44,7 +38,6 @@ services:
       - PGPORT=$PGPORT
       - PGSSLMODE=require
       - PAPERPOD_SCHEMA=authentication
-      #- PGOPTIONS="-c search_path=authentication"
       - DATABASE_CA=$DATABASE_CA
   web:
     image: olaven/paperpod-web@$WEB_DIGEST


### PR DESCRIPTION
The old setup relied on redirecting http traffic to https manually.

The service now runs behind a gateway, and should not have to care about these things. 