### PR TITLE
Terraform dev env working with M1 mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ STRIPE_PUBLISHABLE_KEY=<STRIPE_PUBLISHABLE_KEY>
 STRIPE_API_KEY=<STRIPE_API_KEY> # must have permissions to deal with payments and products
 ULTRAHOOK_API_KEY=<ULTRAHOOK_API_KEY>
 LOG_LEVEL=trace
+STRIPE_COUPON_CODE=coupon_code_for_development
 ```
 
 ### Working with the code 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,23 @@ services:
       - POSTGRES_USER=$PGUSER
       - POSTGRES_PASSWORD=$PGPASSWORD
 
+  # This is here because some TF dependencies don't
+  # support M1 macs. Use `de infrastructure /bin/sh`
+  # to use Terraform through this container as a workaround :)
+  infrastructure:
+    build:
+      context: .
+      dockerfile: ./packages/infrastructure/Dockerfile
+    env_file:
+      - .env
+    # keep it running to enable SSH-ing into it: https://stackoverflow.com/a/45450456/8543529
+    command: tail -F anything
+    environment:
+      AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+      TF_VAR_stripe_api_token: $STRIPE_API_KEY
+      TF_VAR_test_user_coupon_code: $STRIPE_COUPON_CODE
+
   metabase:
     image: metabase/metabase
     env_file:

--- a/packages/infrastructure/Dockerfile
+++ b/packages/infrastructure/Dockerfile
@@ -1,0 +1,17 @@
+# Several of the terraform modules this projects 
+# depends on does not support M1 macs which makes 
+# local development a bit weird. 
+#
+# This Dockerfile can be accessed through the 
+# compose setup of this projects and infra code 
+# can be run from there.
+
+FROM alpine:3.15.4
+
+# install terraform
+RUN apk add gnupg curl
+RUN apk add terraform
+
+# copy over modules 
+COPY ./packages/infrastructure infrastructure 
+WORKDIR infrastructure

--- a/packages/infrastructure/README.md
+++ b/packages/infrastructure/README.md
@@ -1,6 +1,7 @@
 # Infrastructure
 
 The infrastructure is set up with [terraform](https://www.terraform.io/).
+Please see [installation instructions for your system](https://learn.hashicorp.com/tutorials/terraform/install-cli) to install the CLI.
 
 ## Expected environment variables
 
@@ -16,8 +17,9 @@ TODO: update when actually implemented
 - validates/plans on every push
 - actually applies if merged to `main`
 
-## What does it confgure?
+## What's managed by it?
 
 - [Backend](https://www.terraform.io/docs/language/settings/backends/index.html) in [Amazon S3](https://aws.amazon.com/s3/)
 - TODO: Stripe
 - TODO: Digitalocean
+- TODO: Github

--- a/packages/infrastructure/main.tf
+++ b/packages/infrastructure/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.70"
+      version = "~> 4.14"
     }
 
     stripe = {
@@ -19,7 +19,7 @@ terraform {
 
     github = {
       source  = "integrations/github"
-      version = "~> 4.4.0"
+      version = "~> 4.24.1"
     }
 
     digitalocean = {


### PR DESCRIPTION
The Github Terraform module does not support darwin_arm.
This makes it hard to work with the terraform code locally.

This PR gets around that by creating a docker image that
one can run Terraform through if need be.

The ergonomics are decent, so it's an OK workaround
until it starts working natively again.

This is a prerequisite for #192.