### PR TITLE
Avoid multiple signups race condition

### DIFF
--- a/packages/server/src/database/authentication.sql
+++ b/packages/server/src/database/authentication.sql
@@ -17,7 +17,12 @@ END
 $$;
 
 ALTER TABLE authentication.users
-ADD COLUMN IF NOT EXISTS subscription Subscription NOT NULL DEFAULT 'inactive'; 
+    ADD COLUMN IF NOT EXISTS subscription Subscription NOT NULL DEFAULT 'inactive'; 
 
 ALTER TABLE authentication.users
-ADD COLUMN IF NOT EXISTS subscription_id text DEFAULT null; 
+    ADD COLUMN IF NOT EXISTS subscription_id text DEFAULT null; 
+
+-- email has to be unique to avoid race conditions creating multiple users
+ALTER TABLE authentication.users
+    DROP CONSTRAINT IF EXISTS email_unique
+    ADD CONSTRAINT IF NOT EXISTS email_unique UNIQUE (email);


### PR DESCRIPTION
User signup bases itself on `.email` when checking if a
user already exists. However, this is not a primary key
and when many calls with the same credentials are done
~at once, we have a race condition.

To fix this:
- make `authentication.users.email` unique
- maybe do the insert in a transaction?

When done, this closes https://github.com/olaven/paperpod/issues/200