### PR TITLE
Removing CA expected in configuration

### DIFF
--- a/packages/server/src/boot.ts
+++ b/packages/server/src/boot.ts
@@ -1,9 +1,9 @@
 import { logger } from "@paperpod/common";
-import readPkg from "read-pkg-up";
 import express from "express";
+import readPkg from "read-pkg-up";
 import { appWithEnvironment } from "./app/appWithEnvironment";
-import { migrate, SchemaName } from "./database/migrate";
 import { getConfiguration } from "./database/configuration";
+import { migrate, SchemaName } from "./database/migrate";
 
 /**
  * Returns a nice health response
@@ -35,6 +35,7 @@ export const bootWithMigrations = async (
   options: BootOptions = {}
 ) => {
   const configuration = getConfiguration();
+  logger.debug({message: "In boot with migrations", configuration, schema})
   await migrate({ configuration, schema });
   return boot(`/${schema}`, app, options);
 };

--- a/packages/server/src/database/configuration.ts
+++ b/packages/server/src/database/configuration.ts
@@ -17,7 +17,9 @@ export type Configuration = {
 /**
  * @returns env-dependent db configuration
  */
-export const getConfiguration = (): Configuration =>
+export const getConfiguration = () => {}
+  /* 
+  FIXME: adapt if not needed with DO app spec 
   process.env.NODE_ENV === "production"
     ? {
         ssl: {
@@ -26,3 +28,4 @@ export const getConfiguration = (): Configuration =>
         },
       }
     : {};
+ */


### PR DESCRIPTION
Relevant when testing setup with app spec.
Will likely revert this later, but that's not
relevant now, as the project is not deployed and/or used by anyone.