### PR TITLE
Remove publish on test branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - sketch/do-app-system
 
 jobs:
     deploy: 


### PR DESCRIPTION
I specified that deploy should happen on `sketch/do-app-system` when
working on https://github.com/olaven/paperpod/pull/208. This was only
meant to be active when developing and should thus now be removed.